### PR TITLE
Improvements for the next version of opam + other changes

### DIFF
--- a/src/opam_bin_lib/commandConfig.ml
+++ b/src/opam_bin_lib/commandConfig.ml
@@ -194,6 +194,10 @@ let cmd = {
                 from the list. A glob regexp can also be used for \
                 SWITCH.";
 
+    [ "save" ], Arg.Set need_saving,
+    Ezcmd.info
+      "Save new version of config file (~/.opam/plugins/opam-bin/config)";
+
     [ "protected-switches" ], Arg.String (fun s ->
         modify_list_of_switches Config.protected_switches s ;
         need_saving := true;

--- a/src/opam_bin_lib/commandPostSession.ml
+++ b/src/opam_bin_lib/commandPostSession.ml
@@ -1,0 +1,40 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 OCamlPro & Origin Labs                               *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Ezcmd.TYPES
+(* open EzFile.OP *)
+
+let cmd_name = "post-session"
+
+let action args =
+  Misc.log_cmd cmd_name args ;
+  Misc.global_log "Session ended";
+  let filename = Globals.opambin_session_msg_file () in
+  if Sys.file_exists filename then
+    let s = EzFile.read_file filename in
+    Printf.printf "%s actions:\n%s%!" Globals.command s;
+    Sys.remove filename
+      (*
+  else
+    Printf.printf "File %s does not exist\n%!" filename
+*)
+
+let cmd =
+  let args = ref [] in
+  Arg.{
+  cmd_name ;
+  cmd_action = (fun () -> action !args) ;
+  cmd_args = [
+    [], Anons (fun list -> args := list),
+    Ezcmd.info "args"
+  ];
+  cmd_man = [];
+  cmd_doc = "(opam hook) End Session";
+}

--- a/src/opam_bin_lib/commandPreSession.ml
+++ b/src/opam_bin_lib/commandPreSession.ml
@@ -1,0 +1,47 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 OCamlPro & Origin Labs                               *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Ezcmd.TYPES
+open EzConfig.OP
+(* open EzFile.OP *)
+
+let cmd_name = "pre-session"
+
+let action args =
+  Misc.log_cmd cmd_name args ;
+  Misc.global_log "Session started";
+  begin
+    if !!Config.enabled then
+      if Misc.not_this_switch () then
+        Printf.printf "%s disabled in this switch\n%!" Globals.command
+      else
+        Printf.printf "%s [ creation: %b, sharing: %b ]\n%!" Globals.command
+          !!Config.create_enabled !!Config.share_enabled
+    else
+      Printf.printf "%s disabled\n%!" Globals.command
+  end;
+  let filename = Globals.opambin_session_msg_file () in
+  if Sys.file_exists filename then
+    Sys.remove filename
+  else
+    EzFile.make_dir ~p:true (Filename.dirname filename)
+
+let cmd =
+  let args = ref [] in
+  Arg.{
+  cmd_name ;
+  cmd_action = (fun () -> action !args) ;
+  cmd_args = [
+    [], Anons (fun list -> args := list),
+    Ezcmd.info "args"
+  ];
+  cmd_man = [];
+  cmd_doc = "(opam hook) Start Session";
+}

--- a/src/opam_bin_lib/commandUninstall.ml
+++ b/src/opam_bin_lib/commandUninstall.ml
@@ -17,40 +17,10 @@ wrap-install-commands:
   ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
 *)
 
-let remove_opam_hooks file_contents =
-  let rec iter items found rev =
-    match items with
-    | [] ->
-      if found then begin
-        Printf.eprintf "Found hooks to remove\n%!";
-        Some ( List.rev rev )
-      end
-      else begin
-        Printf.eprintf "No hooks to remove\n%!";
-        None
-      end
-    | item :: items ->
-      match item with
-      | OpamParserTypes.Variable (_, name, _) ->
-        begin
-          match name with
-          | "pre-build-commands"
-          | "wrap-build-commands"
-          | "pre-install-commands"
-          | "wrap-install-commands"
-          | "post-install-commands"
-          | "pre-remove-commands"
-            -> iter items true rev
-          | _ -> iter items found ( item :: rev )
-        end
-      | _ ->
-        iter items found ( item :: rev )
-  in
-  iter file_contents false []
-
 let action () =
   Misc.change_opam_config (fun file_contents ->
-      let file_contents = match remove_opam_hooks file_contents with
+      let file_contents =
+        match CommandInstall.remove_opam_hooks file_contents with
           None -> file_contents
         | Some file_contents -> file_contents
       in

--- a/src/opam_bin_lib/config.ml
+++ b/src/opam_bin_lib/config.ml
@@ -105,6 +105,14 @@ let protected_switches = EzConfig.create_option config
     ( EzConfig.list_option EzConfig.string_option )
     []
 
+let exclude_dirs = EzConfig.create_option config
+    [ "exclude_dirs" ]
+    [ "The list of directories to exclude while computing the hash of sources.";
+      "Can also be overwritten using OPAM_BIN_EXCLUDE";
+    ]
+    ( EzConfig.list_option EzConfig.string_option )
+    [ ".git" ; ".hg" ; "_darcs" ]
+
 let current_version = 1
 (* This option should be used in the future to automatically upgrade
    configuration *)

--- a/src/opam_bin_lib/globals.ml
+++ b/src/opam_bin_lib/globals.ml
@@ -77,6 +77,8 @@ let opambin_switch_temp_dir () =
 let opambin_switch_packages_dir () =
   opam_switch_dir () // "etc" // command // "packages"
 
+let opambin_session_msg_file () =
+  opam_switch_internal_dir () // ( command ^ ".msg" )
 
 (* names of the files created in the package `files` sub-dir *)
 let package_version = "bin-package.version"

--- a/src/opam_bin_lib/main.ml
+++ b/src/opam_bin_lib/main.ml
@@ -19,11 +19,13 @@ let commands = [
   CommandInfo.cmd ;
   CommandSearch.cmd ;
 
+  CommandPreSession.cmd ;
   CommandPreBuild.cmd ;
   CommandWrapBuild.cmd ;
   CommandPreInstall.cmd ;
   CommandWrapInstall.cmd ;
   CommandPostInstall.cmd ;
+  CommandPostSession.cmd ;
   CommandPreRemove.cmd ;
   CommandShare.cmd ;
 ]

--- a/src/opam_bin_lib/misc.ml
+++ b/src/opam_bin_lib/misc.ml
@@ -45,7 +45,11 @@ let info ~name ~version fmt =
           s
         in *)
       append_text_file Globals.opambin_info
-        (Printf.sprintf "%s: %s.%s %s\n" (date()) name version s)) fmt
+        (Printf.sprintf "%s: %s.%s %s\n" (date()) name version s);
+      let filename = Globals.opambin_session_msg_file () in
+      append_text_file filename
+        (Printf.sprintf "* %s.%s %s\n" name version s);
+    ) fmt
 
 let global_log fmt =
   log Globals.opambin_log fmt


### PR DESCRIPTION
* Use the post-session hook to display information
  * add commands `opam bin pre-session` and `opam bin post-session`
  * If a file `$OPAMROOT/$SWITCH/.opam-switch/build/$PACKAGE.opam` exists,
    it is used instead of calling back `opam`
* Add `--save` to `opam bin config` to update the configuration
* New configuration option `exclude_dirs` to mix with the `OPAM_BIN_EXCLUDE`
   env variable to skip some directories while computing the hash of the
   sources. Default is `[ ".git"; ".hg"; "_darcs" ]`, equivalent to
   `.git,.hg,_darcs` for `OPAM_BIN_EXCLUDE`
* Remove directories when creating archives